### PR TITLE
fix: containrd.io pin to 1.7

### DIFF
--- a/digital-ocean/files/var/lib/cloud/scripts/per-instance/002_immich
+++ b/digital-ocean/files/var/lib/cloud/scripts/per-instance/002_immich
@@ -9,6 +9,13 @@
 sudo apt-get update
 sudo apt-get upgrade -y
 
+# Force version 1.7 of container.d
+sudo apt install -y --allow-downgrades --allow-change-held-packages containerd.io=$(apt-cache madison containerd.io | grep "containerd.io | 1.7." | head -n1 | grep -Po '1.7.*~noble') ;
+sudo apt-mark hold containerd.io
+sudo systemctl restart containerd
+sudo apt-get install --reinstall docker-ce
+sudo systemctl restart docker
+
 sudo loginctl enable-linger root
 sudo loginctl enable-linger immich
 

--- a/generic/scripts/015-immich.sh
+++ b/generic/scripts/015-immich.sh
@@ -14,6 +14,13 @@ sudo apt-get install -y curl dbus-user-session
 sudo apt-get install -y uidmap systemd-container
 sudo apt-get install -y docker-ce-rootless-extras
 
+# Force version 1.7 of container.d
+sudo apt install -y --allow-downgrades --allow-change-held-packages containerd.io=$(apt-cache madison containerd.io | grep "containerd.io | 1.7." | head -n1 | grep -Po '1.7.*~noble') ;
+sudo apt-mark hold containerd.io
+sudo systemctl restart containerd
+sudo apt-get install --reinstall docker-ce
+sudo systemctl restart docker
+
 # Place for global immich scripts
 mkdir -p /opt/immich/
 
@@ -118,6 +125,9 @@ chown -R immich:immich /home/immich/.config/
 
 # Reload sysctl.conf to open port 80
 sudo sysctl -p /etc/sysctl.conf
+
+echo "Setting up dockerd-rootless-prerequisites (Install newuidmap & newgidmap binaries)"
+sudo apt-get install -y uidmap
 
 # Set up immich as the immich user so that we have a clean ready environment, and start it
 /bin/su -l -s "/bin/bash" -c 'cd /home/immich ; HOME=/home/immich USER=immich PATH=/usr/bin:/sbin:/usr/sbin:$PATH /opt/immich/init.sh skip-run' immich

--- a/vultr/files/var/lib/cloud/scripts/per-instance/002_immich
+++ b/vultr/files/var/lib/cloud/scripts/per-instance/002_immich
@@ -9,6 +9,13 @@
 sudo apt-get update
 sudo apt-get upgrade -y
 
+# Force version 1.7 of container.d
+sudo apt install -y --allow-downgrades --allow-change-held-packages containerd.io=$(apt-cache madison containerd.io | grep "containerd.io | 1.7." | head -n1 | grep -Po '1.7.*~noble') ;
+sudo apt-mark hold containerd.io
+sudo systemctl restart containerd
+sudo apt-get install --reinstall docker-ce
+sudo systemctl restart docker
+
 sudo loginctl enable-linger root
 sudo loginctl enable-linger immich
 


### PR DESCRIPTION
The version of containerd.io on Ubuntu 24.04 LTS was updated from to 2.2+. It broke the user space running of rootless-docker containers. Which caused the digital ocean droplets of immich to no longer work (on new installs)

I pinned the version of containerd.io 17.x.

This set's it up on the base image, and then also updates it the the latest version of 17.x (instead of the OS latest) on it's initial instance run.

I have confirmed this resolves the issue on both digitalocean and vultr.